### PR TITLE
Allows requirements_txt input parameter

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 install_zip_dependencies(){
 	echo "Installing and zipping dependencies..."
 	mkdir python
-	pip install --target=python -r requirements.txt
+	pip install --target=python -r "${INPUT_REQUIREMENTS_TXT:-requirements.txt}"
 	zip -r dependencies.zip ./python
 }
 


### PR DESCRIPTION
to be used in the workflow `step.with`
https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepswith