### PR TITLE
Allowing use of LAMBDA_FUNCTION_NAME and LAMBDA_LAYER_ARN as plugin inputs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ install_zip_dependencies(){
 
 publish_dependencies_as_layer(){
 	echo "Publishing dependencies as a layer..."
-	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN:-$LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
+	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
 	LAYER_VERSION=$(jq '.Version' <<< "$result")
 	rm -rf python
 	rm dependencies.zip
@@ -18,12 +18,12 @@ publish_dependencies_as_layer(){
 publish_function_code(){
 	echo "Deploying the code itself..."
 	zip -r code.zip . -x \*.git\*
-	aws lambda update-function-code --function-name "${INPUT_LAMBDA_FUNCTION_NAME:-$LAMBDA_FUNCTION_NAME}" --zip-file fileb://code.zip
+	aws lambda update-function-code --function-name "${INPUT_LAMBDA_FUNCTION_NAME}" --zip-file fileb://code.zip
 }
 
 update_function_layers(){
 	echo "Using the layer in the function..."
-	aws lambda update-function-configuration --function-name "${INPUT_LAMBDA_FUNCTION_NAME:-$LAMBDA_FUNCTION_NAME}" --layers "${INPUT_LAMBDA_LAYER_ARN:-$LAMBDA_LAYER_ARN}:${LAYER_VERSION}"
+	aws lambda update-function-configuration --function-name "${INPUT_LAMBDA_FUNCTION_NAME}" --layers "${INPUT_LAMBDA_LAYER_ARN}:${INPUT_LAYER_VERSION}"
 }
 
 deploy_lambda_function(){

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,14 @@ update_function_layers(){
 }
 
 deploy_lambda_function(){
+	if [ ! -z $INPUT_LAMBDA_FUNCTION_NAME ]
+	then
+      		export LAMBDA_FUNCTION_NAME=$INPUT_LAMBDA_FUNCTION_NAME
+	fi
+	if [ ! -z $INPUT_LAMBDA_LAYER_ARN ]
+	then
+      		export LAMBDA_LAYER_ARN=$INPUT_LAMBDA_LAYER_ARN
+	fi
 	install_zip_dependencies
 	publish_dependencies_as_layer
 	publish_function_code


### PR DESCRIPTION
This PR allows the use of LAMBDA_FUNCTION_NAME and LAMBDA_LAYER_ARN as inputs to the GitHub Action. They can be populated from the workflow with the `with` key, and default back to the environment variable if empty.