### PR TITLE
Migrate to v2 of Github Actions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
 FROM python:3.6
 
-LABEL "com.github.actions.name"="Py Lambda Deploy"
-LABEL "com.github.actions.description"="Deploy python code to AWS Lambda with dependencies in a separate layer."
-LABEL "com.github.actions.icon"="layers"
-LABEL "com.github.actions.color"="yellow"
-
-LABEL "repository"="http://github.com/mariamrf/py-lambda-action"
-LABEL "maintainer"="Mariam Maarouf <mrf.mariam@gmail.com>"
-
 RUN apt-get update
 RUN apt-get install -y jq zip
 RUN pip install awscli

--- a/README.md
+++ b/README.md
@@ -2,49 +2,56 @@
 
 [![GitHubActions](https://img.shields.io/badge/listed%20on-GitHubActions-blue.svg)](https://github-actions.netlify.com/py-lambda)
 
-A Github Action to deploy AWS Lambda functions written in Python with their dependencies in a separate layer. For now, only works with Python 3.6.
+A Github Action to deploy AWS Lambda functions written in Python with their dependencies in a separate layer. For now, only works with Python 3.6. PRs welcome.
 
 ## Use
-Doesn't take any arguments. Deploys everything in the repo as code to the Lambda function, and installs/zips/deploys the dependencies as a separate layer the function can then immediately use.
+Deploys everything in the repo as code to the Lambda function, and installs/zips/deploys the dependencies as a separate layer the function can then immediately use.
+
+### Pre-requisites
+In order for the Action to have access to the code, you must use the `actions/checkout@master` job before it. See the example below.
+
 ### Structure
 - Lambda code should be structured normally/as Lambda would expect it.
-- **Dependencies must be stored in a `requirements.txt`**.
+- **Dependencies must be stored in a `requirements.txt`** or a similar file (provide the filename explicitly if that's the case).
+
 ### Environment variables
 Stored as secrets or env vars, doesn't matter. But also please don't put your AWS keys outside Secrets.
 - **AWS Credentials**  
     That includes the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, etc. It's used by `awscli`, so the docs for that [can be found here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html).
-- `LAMBDA_LAYER_ARN`  
+
+### Inputs
+- `lambda_layer_arn`  
     The ARN for the Lambda layer the dependencies should be pushed to **without the version** (every push is a new version).
-- `LAMBDA_FUNCTION_NAME`  
+- `lambda_function_name`  
     The Lambda function name. [From the AWS docs](https://docs.aws.amazon.com/cli/latest/reference/lambda/update-function-code.html), it can be any of the following:
     - Function name - `my-function`  
     - Function ARN - `arn:aws:lambda:us-west-2:123456789012:function:my-function`  
     - Partial ARN - `123456789012:function:my-function`
+- `requirements_txt`
+    The name/path for the `requirements.txt` file. Defaults to `requirements.txt`.
 
 
 ### Example workflow
-```hcl
-workflow "Build & deploy" {
-  on = "push"
-  resolves = ["py-lambda-deploy"]
-}
-
-action "py-lambda-deploy" {
-  needs = "Master"
-  uses = "mariamrf/py-lambda-action@master"
-  secrets = [
-    "AWS_ACCESS_KEY_ID",
-    "AWS_SECRET_ACCESS_KEY",
-    "AWS_DEFAULT_REGION",
-    "LAMBDA_FUNCTION_NAME",
-    "LAMBDA_LAYER_ARN",
-  ]
-}
-
-# Filter for master branch
-action "Master" {
-  uses = "actions/bin/filter@master"
-  args = "branch master"
-}
+```yaml
+name: deploy-py-lambda
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@master
+    - name: Deploy code to Lambda
+      uses: mariamrf/py-lambda-action@v1.0.0
+      with:
+        lambda_layer_arn: 'arn:aws:lambda:us-east-2:123456789012:layer:my-layer'
+        lambda_function_name: 'my-function'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_REGION: 'us-east-2'
 
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,24 @@
+name: Py Lambda Deploy
+author: Mariam Maarouf
+description: Deploy python code to AWS Lambda with dependencies in a separate layer.
+inputs:
+  requirements_txt:
+    description: the name/path to the requirements.txt file
+    required: true
+    default: 'requirements.txt'
+  lambda_layer_arn:
+    description: The ARN for the Lambda layer the dependencies should be pushed to without the version (every push is a new version).
+    required: true
+  lambda_function_name:
+    description: The Lambda function name. Check the AWS docs/readme for examples.
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.requirements_txt }}
+    - ${{ inputs.lambda_layer_arn }}
+    - ${{ inputs.lambda_function_name }}
+branding:
+  icon: 'layers'
+  color: 'yellow'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,13 +3,13 @@
 install_zip_dependencies(){
 	echo "Installing and zipping dependencies..."
 	mkdir python
-	pip install --target=python -r "${INPUT_REQUIREMENTS_TXT:-requirements.txt}"
+	pip install --target=python -r "${INPUT_REQUIREMENTS_TXT}"
 	zip -r dependencies.zip ./python
 }
 
 publish_dependencies_as_layer(){
 	echo "Publishing dependencies as a layer..."
-	local result=$(aws lambda publish-layer-version --layer-name "${LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
+	local result=$(aws lambda publish-layer-version --layer-name "${INPUT_LAMBDA_LAYER_ARN}" --zip-file fileb://dependencies.zip)
 	LAYER_VERSION=$(jq '.Version' <<< "$result")
 	rm -rf python
 	rm dependencies.zip
@@ -18,12 +18,12 @@ publish_dependencies_as_layer(){
 publish_function_code(){
 	echo "Deploying the code itself..."
 	zip -r code.zip . -x \*.git\*
-	aws lambda update-function-code --function-name "${LAMBDA_FUNCTION_NAME}" --zip-file fileb://code.zip
+	aws lambda update-function-code --function-name "${INPUT_LAMBDA_FUNCTION_NAME}" --zip-file fileb://code.zip
 }
 
 update_function_layers(){
 	echo "Using the layer in the function..."
-	aws lambda update-function-configuration --function-name "${LAMBDA_FUNCTION_NAME}" --layers "${LAMBDA_LAYER_ARN}:${LAYER_VERSION}"
+	aws lambda update-function-configuration --function-name "${INPUT_LAMBDA_FUNCTION_NAME}" --layers "${INPUT_LAMBDA_LAYER_ARN}:${LAYER_VERSION}"
 }
 
 deploy_lambda_function(){


### PR DESCRIPTION
Resolves #3 (thanks @kylearector!) and makes it possible to use the Action after the old version was deprecated.