### PR TITLE
python version update to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.9
 
 RUN apt-get update
 RUN apt-get install -y jq zip


### PR DESCRIPTION
Python 3.9 is supported in aws lambda.